### PR TITLE
ci: enable super-linter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+IndentWidth: 2

--- a/.github/linters/.commitlintrc.yml
+++ b/.github/linters/.commitlintrc.yml
@@ -1,0 +1,3 @@
+---
+extends:
+  - '@commitlint/config-conventional'

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,7 @@
+---
+MD007:                 # Unordered list indentation
+  indent: 2            # Consider disable MD005 if things fail on ordered list
+MD013:                 # Line length 80 is far to short
+  line_length: 999     # We allow soft wrapped paragraphs and raw code outputs
+MD029: false           # Ordered list item prefix
+MD033: false           # Allow inline HTML

--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -1,0 +1,9 @@
+---
+extends: relaxed
+
+rules:
+  line-length:
+    max: 128
+  indentation:
+    spaces: 2
+    indent-sequences: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,50 @@
+---
+name: super-linter
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout with history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Work around super-linter
+        shell: bash
+        run: |
+          # Work-around for config file detection
+          cp .github/linters/.commitlintrc.yml .commitlintrc.yml
+          # Work-around for SHA detection
+          # https://github.com/super-linter/super-linter/issues/6316#issuecomment-2510205626
+          if [[ '${{ github.event_name }}' == 'pull_request' ]]; then
+            echo 'GITHUB_BEFORE_SHA=${{ github.event.pull_request.base.sha }}' >> "${GITHUB_ENV}"
+          fi
+
+      - name: Run super-linter
+        uses: super-linter/super-linter/slim@v7.2.0
+        env:
+          # super-linter configurations
+          MULTI_STATUS: false
+          SUPPRESS_POSSUM: true
+          VALIDATE_ALL_CODEBASE: false
+          # language configurations
+          VALIDATE_CLANG_FORMAT: true
+          VALIDATE_MARKDOWN: true
+          VALIDATE_YAML: true
+          # misc configurations
+          ENFORCE_COMMITLINT_CONFIGURATION_CHECK: true
+          VALIDATE_GIT_COMMITLINT: true
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_GITLEAKS: true


### PR DESCRIPTION
Includes configuration files for
- clang-format (.clang-format)
- commitlint (.commitlintrc.yml)
- markdownlint (.markdown-lint.yml)
- yamllint (.yaml-lint.yml)