### PR TITLE
ci: pass GITHUB_TOKEN to super-linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -14,6 +14,8 @@ jobs:
 
     permissions:
       contents: read
+      packages: read
+      pull-requests: write
 
     steps:
       - name: Checkout with history
@@ -24,6 +26,7 @@ jobs:
       - name: Run super-linter
         uses: super-linter/super-linter/slim@v8.6.0
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # super-linter configurations
           MULTI_STATUS: false
           SUPPRESS_POSSUM: true


### PR DESCRIPTION
Fixes the Lint failure currently blocking #21 (and every future PR):

```
[FATAL] Failed to get GITHUB_TOKEN. Terminating because status reports (MULTI_STATUS: false)
or pull request summary comments (ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: true) were
explicitly enabled, but GITHUB_TOKEN was not provided.
```

Follows the working setup in [WasmEdge/wasmedgeup's `superlinter.yml`](https://github.com/WasmEdge/wasmedgeup/blob/master/.github/workflows/superlinter.yml):

- pass the **automatic** workflow token (`secrets.GITHUB_TOKEN`) to super-linter — no repo/org secret needed
- grant the job `packages: read` + `pull-requests: write` so the PR summary comment can be posted

Deliberately **not** ported from wasmedgeup: the `GITHUB_BEFORE_SHA` workaround step — it was already removed from this repo in #8 as resolved upstream ([super-linter#6316](https://github.com/super-linter/super-linter/issues/6316)).

This PR's own Lint check runs with the fixed workflow, so a green check here validates the fix.

---

🤖 Generated by Claude Fable 5 with [Claude Code](https://claude.com/claude-code)