### PR TITLE
ci: exclude imported thirdparty and wasm_bpf fixtures from super-linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -28,6 +28,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # super-linter configurations
+          # imported third-party/generated code and BPF test fixtures are not
+          # format-enforced upstream (see .github/scripts/clang-format.sh there)
+          FILTER_REGEX_EXCLUDE: .*/(thirdparty|test/plugins/wasm_bpf/assets)/.*
           MULTI_STATUS: false
           SUPPRESS_POSSUM: true
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
## PR summary

Part of #45 (leftover from the import PR #44): excludes imported third-party/generated code and BPF test fixtures from super-linter, so PRs touching those paths stop failing clang-format. Sequenced before #24 to keep every subsequent PR green.

## Implementation design

One env addition to `.github/workflows/super-linter.yml`:

```yaml
FILTER_REGEX_EXCLUDE: .*/(thirdparty|test/plugins/wasm_bpf/assets)/.*
```

Covers the two path groups that failed Lint on #44: `thirdparty/wasi_crypto/api.hpp` (generated from witx) and `test/plugins/wasm_bpf/assets/bpf-sources/` (BPF fixtures compiled to wasm in tests).

## Design decisions

- **Mirrors upstream policy**: upstream's `.github/scripts/clang-format.sh` lints only `include lib tools plugins examples` and pipes through `grep -v "/thirdparty/"` — so `thirdparty/` is excluded there and `test/` is never format-checked at all. We exclude only what is genuinely not ours to format and keep our own tests lintable.
- **`test/plugins/wasi_crypto/asymmetric.cpp` deliberately not excluded**: it is first-party test code that upstream simply never linted (not version drift). It gets reformatted in #24.

## Commit slicing

Single commit: `ci: exclude imported thirdparty and wasm_bpf fixtures from super-linter`.

## Test plan

- [x] Regex verified locally against the #44 failure paths with super-linter's `/github/workspace/`-prefixed matching: `thirdparty/wasi_crypto/api.hpp` and `test/plugins/wasm_bpf/assets/bpf-sources/*` excluded; `asymmetric.cpp`, `plugins/**`, and repo-root files remain linted
- [x] super-linter green on this PR (validates the YAML edit itself; the workflow runs from this PR's merge ref, so the new config is active) — Lint passed in 1m28s, DCO passed

## Non-goals / afterwards

- Reformat `asymmetric.cpp` + decide the pinned clang-format version → #24 (upstream pins clang-format-20)
- Remaining #45 items (import guidelines doc) unaffected

---

🤖 Generated by Claude Fable 5 with [Claude Code](https://claude.com/claude-code)
