### PR TITLE
ci: adopt WasmEdge clang-format lint method (#45)

### DIFF
--- a/.github/scripts/clang-format.sh
+++ b/.github/scripts/clang-format.sh
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+
+# Usage: $0 clang-format(version >= 10.0)
+# $ bash clang-format.sh `which clang-format`
+#
+# Mirrors WasmEdge/WasmEdge's .github/scripts/clang-format.sh. Only the first-party
+# C/C++ tree present in this repo (plugins) is format-checked; thirdparty/ is excluded
+# and test/ is intentionally not format-enforced, matching upstream policy.
+
+lint() {
+    local targets="plugins"
+    local clang_format="${1}"
+
+    if [ "$#" -ne 1 ]; then
+        echo "please provide clang-format command. Usage ${0} `which clang-format`"
+        exit 1
+    fi
+
+    if [ ! -f "${clang_format}" ]; then
+        echo "clang-format not found. Please install clang-format first"
+        exit 1
+    fi
+
+    find ${targets} -type f -iname *.[ch] -o -iname *.cpp -o -iname *.[ch]xx \
+        | grep -v "/thirdparty/" \
+        | xargs -n1 ${clang_format} -i -style=file -Werror --dry-run
+
+    exit $?
+}
+
+lint $@

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,27 @@
+---
+name: clang-format
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  clang-format:
+    name: Clang-Format
+    runs-on: ubuntu-24.04  # https://github.com/actions/runner-images/issues/10636
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Install clang-format-22
+        run: |
+          curl -sSfL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+          sudo add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-22 main"
+          sudo apt update
+          sudo apt install -y clang-format-22
+      - name: Run clang-format
+        run: bash ./.github/scripts/clang-format.sh "$(which clang-format-22)"

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -32,7 +32,8 @@ jobs:
           SUPPRESS_POSSUM: true
           VALIDATE_ALL_CODEBASE: false
           # language configurations
-          VALIDATE_CLANG_FORMAT: true
+          # clang-format is handled by .github/workflows/clang-format.yml, which
+          # mirrors upstream WasmEdge's pinned-version clang-format method.
           VALIDATE_MARKDOWN: true
           VALIDATE_YAML: true
           # misc configurations


### PR DESCRIPTION
## PR summary

Part of #45 (lint leftover from import PR #44): replaces super-linter's bundled clang-format with upstream WasmEdge's own clang-format method, so PRs stop failing clang-format on imported/generated/test paths and the clang-format version is pinned (no more drift). **Supersedes #46**, which used a super-linter `FILTER_REGEX_EXCLUDE` workaround.

## Implementation design

- **`.github/scripts/clang-format.sh`** — copied from upstream `WasmEdge/WasmEdge` verbatim except `targets="plugins"` (the only first-party C/C++ tree in this repo). Lints `plugins/`, pipes through `grep -v "/thirdparty/"`, runs `clang-format -Werror --dry-run`. `test/` is intentionally not format-checked, matching upstream.
- **`.github/workflows/clang-format.yml`** — installs a pinned `clang-format-22` (the version current upstream master uses) from apt.llvm.org and runs the script. Mirrors upstream's `reusable-call-linter.yml` install steps, adapted to this repo's workflow conventions (`pull_request → main`, `actions/checkout@v7`, minimal permissions).
- **`super-linter.yml`** — drop `VALIDATE_CLANG_FORMAT`; super-linter keeps markdown, yaml, commitlint, github-actions, gitleaks.

## Design decisions

- **Follow the WasmEdge solution** rather than a super-linter exclude hack. Upstream lints only `include lib tools plugins examples` minus `thirdparty/`, never `test/`, with a pinned clang-format. Mapping that to this repo (only `plugins/` is first-party) resolves all three #44 failures structurally — `thirdparty/wasi_crypto/api.hpp` (generated), `test/plugins/wasm_bpf/assets/` (fixtures), and `test/plugins/wasi_crypto/asymmetric.cpp` (test code) all fall outside scope — and pins the version so drift can't recur.
- **clang-format-22**: matches current upstream master. Verified locally that all 347 in-scope `plugins/` files are already clean under it, so **no reformatting commit is needed**.
- **`.clang-format` already matches upstream** (`BasedOnStyle: LLVM`, `IndentWidth: 2`) — confirmed byte-identical, so there is no style-config divergence to reconcile.

## Commit slicing

Single commit: `ci: adopt WasmEdge clang-format lint method (#45)`.

## Test plan

- [x] `bash .github/scripts/clang-format.sh "$(which clang-format-22)"` exits `0` locally against `plugins/` (347 files in scope, 0 reformatted)
- [x] `.clang-format` confirmed identical to upstream WasmEdge
- [ ] CI: this PR's new `clang-format` job runs green (the workflow validates itself on this PR)
- [ ] CI: super-linter still green with clang-format removed

## Non-goals / afterwards

- The #45 import-guidelines doc (`docs/IMPORTING.md`) is a separate leftover, not in this PR
- **Supersedes #46** — needs a human decision to close it; see the comment below

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
