### PR TITLE
chore: remove deprecated wasmedge_llmc plugin (#36)

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -52,11 +52,6 @@ if(WASMEDGE_PLUGIN_IMAGE)
   endif()
 endif()
 
-# WasmEdge plug-in: LLMC.
-if(WASMEDGE_PLUGIN_LLMC)
-  add_subdirectory(wasmedge_llmc)
-endif()
-
 # WasmEdge plug-in: OCR.
 if(WASMEDGE_PLUGIN_OCR)
   add_subdirectory(wasmedge_ocr)

--- a/plugins/wasmedge_llmc/CMakeLists.txt
+++ b/plugins/wasmedge_llmc/CMakeLists.txt
@@ -1,4 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2019-2024 Second State INC
-
-message(FATAL_ERROR "WasmEdge LLMC plugin is removed due to the upstream end-of-life. Reference: https://github.com/WasmEdge/llm.c")

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -39,11 +39,6 @@ if(WASMEDGE_PLUGIN_IMAGE)
   endif()
 endif()
 
-# WasmEdge plug-in: LLMC.
-if(WASMEDGE_PLUGIN_LLMC)
-  add_subdirectory(wasmedge_llmc)
-endif()
-
 # WasmEdge plug-in: OpenCV-mini.
 if(WASMEDGE_PLUGIN_OPENCVMINI)
   # wasmedge_opencvmini is currently supported only on Linux and macOS.

--- a/test/plugins/wasmedge_llmc/CMakeLists.txt
+++ b/test/plugins/wasmedge_llmc/CMakeLists.txt
@@ -1,4 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2019-2024 Second State INC
-
-message(FATAL_ERROR "WasmEdge LLMC plugin is removed due to the upstream end-of-life. Reference: https://github.com/WasmEdge/llm.c")


### PR DESCRIPTION
## PR summary

Remove the **`wasmedge_llmc`** plugin. Upstream deprecated it (WasmEdge/WasmEdge#4964); rather than migrate it into cpp-plugins, we drop it. **Closes #36**. Decision flagged in #36 / #22.

Rebased onto `main` after the refresh re-import **#50** merged — that re-import carried upstream's deprecation commit, which had already emptied the plugin down to stub `CMakeLists.txt` files. This PR removes those residuals and the build wiring.

## Implementation design

- `git rm -r plugins/wasmedge_llmc test/plugins/wasmedge_llmc` — on current `main` these dirs contain only the residual stub `CMakeLists.txt` (source already removed upstream via #50).
- Remove the `if(WASMEDGE_PLUGIN_LLMC) add_subdirectory(wasmedge_llmc)` stanza from `plugins/CMakeLists.txt` and `test/plugins/CMakeLists.txt`.
- **`libpiper` is intentionally untouched** — it belongs to `wasi_nn` (`utils/wasi-nn/`, `utils/build_libpiper.sh`), not llmc.

## Design decisions

- Removal, not deprecation-carry: cpp-plugins shouldn't ship a plugin upstream is dropping.
- Verified no dangling references remain (`wasmedge_llmc` / `WASMEDGE_PLUGIN_LLMC` / `wasmedgePluginWasmEdgeLLMC` all gone).

## Commit slicing

Single authored commit: `chore: remove deprecated wasmedge_llmc plugin (#36)`.

## Test plan

- [x] No remaining `wasmedge_llmc` / `WASMEDGE_PLUGIN_LLMC` references in the tree
- [x] `libpiper` / wasi_nn files intact
- [x] clang-format (clang-format-22, #49 method) passes — exit 0
- [x] Rebased onto post-#50 `main`; clean (no conflicts)
- [ ] CI: clang-format / super-linter / commitlint expected green; DCO green (single signed commit, author == sign-off)

## Non-goals / afterwards

- Upstream `option(WASMEDGE_PLUGIN_LLMC ...)` declaration removal lives in WasmEdge core → epic #28
- Build system / migration (#24, #25) unaffected

---

🤖 Generated by Claude Opus 4.8 (1M context) with [Claude Code](https://claude.com/claude-code)
